### PR TITLE
Fix projection manager bug

### DIFF
--- a/spec/Cocoders/ReadModel/ProjectionManagerSpec.php
+++ b/spec/Cocoders/ReadModel/ProjectionManagerSpec.php
@@ -43,7 +43,8 @@ class ProjectionManagerSpec extends ObjectBehavior
 
         $event->getName()->willReturn('EventNameOccurred');
         $secondEvent->getName()->willReturn('OtherEventOccurred');
-        $this->reload(new EventStream(
+        $this->clear();
+        $this->notify(new EventStream(
             new EventStream\Name('test'),
             [$event->getWrappedObject(), $secondEvent->getWrappedObject()])
         );

--- a/src/Cocoders/ReadModel/ProjectionManager.php
+++ b/src/Cocoders/ReadModel/ProjectionManager.php
@@ -27,12 +27,15 @@ final class ProjectionManager
         $this->subscribers->registerSubscriber($eventName, $projection);
     }
 
-    public function reload(EventStream $eventStream)
+    public function clear()
     {
         foreach ($this->projections as $projection) {
             $projection->clear();
         }
+    }
 
+    public function notify(EventStream $eventStream)
+    {
         foreach ($eventStream as $event) {
             $this->notifyProjections($event);
         }


### PR DESCRIPTION
Bug cause that other projection data was removed in for next projection rebuilding. Separate clear and notify.
